### PR TITLE
fix: filtering out paths at the relative root of a repository prevents querying the log within a sub-directory

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -24,7 +24,3 @@ name = "go"
 
     [analyzers.meta]
     import_root = "github.com/purpleclay/gitz"
-
-[[analyzers]]
-name = "test-coverage"
-enabled = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,3 @@ jobs:
     with:
       version: ${{ vars.GOLANGCI_LINT_VERSION }}
       go-version: ${{ vars.GO_VERSION }}
-
-  deepsource-coverage:
-    uses: purpleclay/github/.github/workflows/deepsource-coverage.yml@main
-    secrets:
-      deepsource-dsn: ${{ secrets.GH_DEEPSOURCE_DSN }}
-    needs: [test]

--- a/client.go
+++ b/client.go
@@ -178,7 +178,9 @@ func (c *Client) rootDir() (string, error) {
 // ToRelativePath determines if a path is relative to the
 // working directory of the repository and returns the resolved
 // relative path. A [ErrGitNonRelativePath] error will be returned
-// if the path exists outside of the working directory
+// if the path exists outside of the working directory.
+// [RelativeAtRoot] is returned if the path and working directory
+// are equivalent
 func (c *Client) ToRelativePath(path string) (string, error) {
 	root, err := c.rootDir()
 	if err != nil {

--- a/log.go
+++ b/log.go
@@ -90,11 +90,10 @@ func WithRefRange(fromRef string, toRef string) LogOption {
 // root of the repository. All leading and trailing whitespace will be
 // trimmed from the file paths, allowing empty paths to be ignored.
 //
-// A relative path can be resolved using [ToRelativePath] and will
-// automatically be ignored if it matches the [RelativeAtRoot] constant
+// A relative path can be resolved using [ToRelativePath].
 func WithPaths(paths ...string) LogOption {
 	return func(opts *logOptions) {
-		opts.LogPaths = trimAndRemove(RelativeAtRoot, paths...)
+		opts.LogPaths = trim(paths...)
 	}
 }
 


### PR DESCRIPTION
closes #86 