### PR TITLE
fix: slice containing empty string is returned when nothing is staged

### DIFF
--- a/show.go
+++ b/show.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	dateFormat   = "Mon Jan 02 15:04:05 2006 -0700"
+	dateFormat   = "Mon Jan _2 15:04:05 2006 -0700"
 	commitIndent = "    "
 )
 

--- a/stage.go
+++ b/stage.go
@@ -81,5 +81,9 @@ func (c *Client) Staged() ([]string, error) {
 		return nil, err
 	}
 
+	if diff == "" {
+		return nil, nil
+	}
+
 	return strings.Split(diff, "\n"), nil
 }


### PR DESCRIPTION
closes #115 