### PR TITLE
fix: commit date is not being parsed due to invalid date time format

### DIFF
--- a/show.go
+++ b/show.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	dateFormat   = "Mon Jan 02 15:04:05 2006 -0700"
+	dateFormat   = "Mon Jan _2 15:04:05 2006 -0700"
 	commitIndent = "    "
 )
 


### PR DESCRIPTION
closes #116 