### PR TITLE
ci: don't run suite of ci checks when tagging a new release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@
 name: ci
 on:
   push:
-    tags:
-      - "v*.*.*"
     branches:
       - main
     paths:


### PR DESCRIPTION
closes #124 