### PR TITLE
fix: when initialising a repository with a log, ensure commits are associated with a file

### DIFF
--- a/gittest/repository.go
+++ b/gittest/repository.go
@@ -545,7 +545,7 @@ func flipExecutableBit(t *testing.T, path string) {
 	if perms&0o100 != 0 {
 		require.NoError(t, os.Chmod(path, perms&^0o100), "failed to turn on executable bit")
 	} else {
-		require.NoError(t, os.Chmod(path, perms|0100), "failed to turn off executable bit")
+		require.NoError(t, os.Chmod(path, perms|0o100), "failed to turn off executable bit")
 	}
 }
 

--- a/gittest/repository_test.go
+++ b/gittest/repository_test.go
@@ -469,12 +469,14 @@ func TestLogBetween(t *testing.T) {
 
 func TestLogFor(t *testing.T) {
 	log := `(main) chore: this should also appear in log
-	chore: this should appear in log`
+chore: this should appear in log`
 	gittest.InitRepository(t, gittest.WithLog(log))
 
 	localLog := gittest.LogFor(t, ".")
-	require.Len(t, localLog, 1)
-	assert.Equal(t, gittest.InitialCommit, localLog[0].Message)
+	require.Len(t, localLog, 3)
+	assert.Equal(t, "chore: this should also appear in log", localLog[0].Message)
+	assert.Equal(t, "chore: this should appear in log", localLog[1].Message)
+	assert.Equal(t, gittest.InitialCommit, localLog[2].Message)
 }
 
 func TestTag(t *testing.T) {


### PR DESCRIPTION
closes #175 